### PR TITLE
Implementing Fadeshow as Library WIP

### DIFF
--- a/manifest.scl
+++ b/manifest.scl
@@ -4,8 +4,7 @@ imports = {
   fps-pitch = "themes/fps-pitch",
   slideshow-template-theme = "themes/slideshow-template-theme",
 
-  fadeshow-theme = "themes/fadeshow",
-  fadeshow = "themes/fadeshow/stylesheets",
+  fadeshow-theme = "themes/fadeshow-theme",
 
   lighttouch-logging = "packages/lighttouch-logging",
   lighttouch-json-interface = "packages/lighttouch-json-interface",
@@ -88,10 +87,6 @@ lighttouch-change-management = {
 
 lighttouch-default-content = {
   url = "https://github.com/foundpatterns/lighttouch-default-content",
-}
-
-fadeshow = {
-  url = "https://github.com/alexerlandsson/css-fadeshow",
 }
 
 fadeshow-theme = {

--- a/manifest.scl
+++ b/manifest.scl
@@ -4,6 +4,9 @@ imports = {
   fps-pitch = "themes/fps-pitch",
   slideshow-template-theme = "themes/slideshow-template-theme",
 
+  fadeshow-theme = "themes/fadeshow",
+  fadeshow = "themes/fadeshow/stylesheets",
+
   lighttouch-logging = "packages/lighttouch-logging",
   lighttouch-json-interface = "packages/lighttouch-json-interface",
   lighttouch-html-interface = "packages/lighttouch-html-interface",
@@ -12,6 +15,7 @@ imports = {
   base-theme = "themes/base-theme",
   send-file-package = "packages/send-file-package",
   lighttouch-change-management = "packages/lighttouch-change-management",
+  
 }
 
 base-theme = {
@@ -86,3 +90,10 @@ lighttouch-default-content = {
   url = "https://github.com/foundpatterns/lighttouch-default-content",
 }
 
+fadeshow = {
+  url = "https://github.com/alexerlandsson/css-fadeshow",
+}
+
+fadeshow-theme = {
+  url = "https://github.com/LuisReyes98/fadeshow-lighttouch",
+}

--- a/manifest.scl
+++ b/manifest.scl
@@ -3,9 +3,6 @@ imports = {
   pitch-deck = "themes/pitch-deck",
   fps-pitch = "themes/fps-pitch",
   slideshow-template-theme = "themes/slideshow-template-theme",
-
-  fadeshow-theme = "themes/fadeshow-theme",
-
   lighttouch-logging = "packages/lighttouch-logging",
   lighttouch-json-interface = "packages/lighttouch-json-interface",
   lighttouch-html-interface = "packages/lighttouch-html-interface",
@@ -87,8 +84,4 @@ lighttouch-change-management = {
 
 lighttouch-default-content = {
   url = "https://github.com/foundpatterns/lighttouch-default-content",
-}
-
-fadeshow-theme = {
-  url = "https://github.com/LuisReyes98/fadeshow-lighttouch",
 }


### PR DESCRIPTION
Implementing fadeshow this way works , 
if this is the intended solution it only needs for fadeshow-theme to be moved to lighttouch themes and fix the url  currently here: https://github.com/LuisReyes98/fadeshow-lighttouch
